### PR TITLE
fix: Allow for building on case sensitive filesystems

### DIFF
--- a/lib/gcode/gcode.cpp
+++ b/lib/gcode/gcode.cpp
@@ -1,4 +1,4 @@
-#include <Gcode.h>
+#include <gcode.h>
 
 String gCode = "";
 

--- a/lib/helpers/helpers.cpp
+++ b/lib/helpers/helpers.cpp
@@ -1,4 +1,4 @@
-#include <Helpers.h>
+#include <helpers.h>
 
 struct Arc
 {


### PR DESCRIPTION
Here is a fix for a minor issue I found with the includes. When compiling on linux, it was unable to find the headers because of case sensitivity. I believe this is also the same on Mac OSX. The changes will not affect Windows systems.

In other news - I've got a working drawing robot with this code, and it works as expected. I like the UI.

However, using the cheap servos I have used gives me consistent travel across the entire range of movement, they consistently jump sections, but the quirkyness is interesting none the less.